### PR TITLE
add immediate loop dialect with repeat statement

### DIFF
--- a/src/bloqade/decoders/dialects/__init__.py
+++ b/src/bloqade/decoders/dialects/__init__.py
@@ -1,1 +1,1 @@
-from . import annotate as annotate
+from . import annotate as annotate, immediate_loop as immediate_loop

--- a/src/bloqade/decoders/dialects/immediate_loop/__init__.py
+++ b/src/bloqade/decoders/dialects/immediate_loop/__init__.py
@@ -1,0 +1,3 @@
+from . import stmts as stmts
+from ._dialect import dialect as dialect
+from ._interface import repeat as repeat

--- a/src/bloqade/decoders/dialects/immediate_loop/_dialect.py
+++ b/src/bloqade/decoders/dialects/immediate_loop/_dialect.py
@@ -1,0 +1,3 @@
+from kirin import ir
+
+dialect = ir.Dialect("imm_loop")

--- a/src/bloqade/decoders/dialects/immediate_loop/_interface.py
+++ b/src/bloqade/decoders/dialects/immediate_loop/_interface.py
@@ -1,0 +1,11 @@
+from typing import Any, Generator
+from contextlib import contextmanager
+
+from kirin.lowering import wraps
+
+from .stmts import Repeat
+
+
+@wraps(Repeat)
+@contextmanager
+def repeat(count: int) -> Generator[Any, None, None]: ...

--- a/src/bloqade/decoders/dialects/immediate_loop/stmts.py
+++ b/src/bloqade/decoders/dialects/immediate_loop/stmts.py
@@ -1,0 +1,37 @@
+from typing import cast
+
+from kirin import ir, types
+from kirin.decl import info, statement
+from kirin.lowering.python.traits import FromPythonWithSingleItem
+
+from ._dialect import dialect
+
+
+@statement(dialect=dialect)
+class Repeat(ir.Statement):
+    """
+    Execute a series of statements a fixed number of times. This can be seen as a stricter version of the
+    Kirin `scf.For` statement directly mappable to Stim REPEAT semantics.
+    """
+
+    name = "repeat"
+    traits = frozenset({FromPythonWithSingleItem()})
+    count: ir.SSAValue = info.argument(types.Int)
+    body: ir.Region = info.region(multi=False)
+
+    def __init__(
+        self,
+        count: ir.SSAValue,
+        body: ir.Region | ir.Block,
+    ):
+        if body.IS_REGION:
+            body_region = cast(ir.Region, body)
+            if body_region.blocks:
+                body_block = body_region.blocks[0]
+            else:
+                body_block = None
+        else:
+            body_block = cast(ir.Block, body)
+            body_region = ir.Region(body_block)
+
+        super().__init__(args=(count,), regions=(body_region,), args_slice={"count": 0})

--- a/test/test_immediate_loop.py
+++ b/test/test_immediate_loop.py
@@ -1,0 +1,31 @@
+from kirin import ir
+from kirin.prelude import structural_no_opt
+
+from bloqade.decoders.dialects import immediate_loop
+from bloqade.decoders.dialects.immediate_loop.stmts import Repeat
+
+
+@ir.dialect_group(structural_no_opt.add(immediate_loop.dialect))
+def imm_loop_kernel(self):
+    def run_pass(mt):
+        return mt
+
+    return run_pass
+
+
+@imm_loop_kernel
+def use_repeat():
+    x = 1
+    with immediate_loop.repeat(100):
+        x = x + 1
+    return x
+
+
+use_repeat.print()
+
+
+def test_repeat_lowering():
+    stmt = use_repeat.callable_region.blocks[0].stmts.at(-2)
+    assert isinstance(stmt, Repeat)
+    assert len(stmt.body.blocks) == 1
+    assert len(stmt.body.blocks[0].stmts) >= 1

--- a/test/test_imports.py
+++ b/test/test_imports.py
@@ -52,3 +52,14 @@ def test_interface_functions():
 
     assert callable(annotate.set_detector)
     assert callable(annotate.set_observable)
+
+
+def test_immediate_loop_exports():
+    from bloqade.decoders.dialects import immediate_loop
+
+    # Statements (via stmts)
+    assert hasattr(immediate_loop.stmts, "Repeat")
+
+    # Interface functions
+    assert hasattr(immediate_loop, "repeat")
+    assert callable(immediate_loop.repeat)


### PR DESCRIPTION
I got the idea to name the dialect "immediate loop" because of the "immediate" instructions you see in MIPS/RISC-V where you need to provide the data to operate on as part of the instruction itself.