### PR TITLE
feat: expose bit packing utilities

### DIFF
--- a/src/bloqade/decoders/_decoders/mld/utils.py
+++ b/src/bloqade/decoders/_decoders/mld/utils.py
@@ -1,28 +1,6 @@
-from __future__ import annotations
-
-import numpy as np
-
-
-def pack_boolean_array(arr: np.ndarray) -> np.ndarray:
-    """Pack a boolean array into int64 (each row becomes one int)."""
-    data_len = arr.shape[1]
-    return np.sum(arr << np.arange(data_len), axis=1)  # type: ignore[arg-type]
-
-
-def unpack_boolean_array(arr: np.ndarray, data_len: int) -> np.ndarray:
-    """Unpack int64 array back to boolean array."""
-    return (arr.reshape(-1, 1) & (1 << np.arange(data_len))) > 0
-
-
-def shots_to_counts(shots: np.ndarray) -> np.ndarray:
-    """Convert boolean shots array to histogram of counts."""
-    packed_shots = pack_boolean_array(shots)
-    counts = np.bincount(packed_shots, minlength=2 ** shots.shape[1])
-    return counts
-
-
-def det_obs_shots_to_counts(det_shots: np.ndarray, obs_shots: np.ndarray) -> np.ndarray:
-    """Convert detector and observable shots into combined counts."""
-    shots = np.concatenate([det_shots, obs_shots], axis=1)
-    counts = shots_to_counts(shots)
-    return counts
+from bloqade.decoders.bit_packing import (
+    shots_to_counts as shots_to_counts,
+    pack_boolean_array as pack_boolean_array,
+    unpack_boolean_array as unpack_boolean_array,
+    det_obs_shots_to_counts as det_obs_shots_to_counts,
+)

--- a/src/bloqade/decoders/bit_packing.py
+++ b/src/bloqade/decoders/bit_packing.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import numpy as np
+import numpy.typing as npt
+
+
+def pack_boolean_array(arr: np.ndarray) -> npt.NDArray[np.uint64]:
+    """Pack each row of a bit array into an unsigned integer.
+
+    Bits are interpreted little-endian along the final axis, so the first
+    column contributes the least-significant bit.
+    """
+
+    bits = np.asarray(arr, dtype=np.uint64)
+    if bits.ndim == 1:
+        bits = bits.reshape(1, -1)
+    if bits.ndim != 2:
+        raise ValueError("arr must be a 1D or 2D bit array.")
+    if bits.shape[1] > 64:
+        raise ValueError("Cannot pack more than 64 bits into uint64 values.")
+    shifts = np.arange(bits.shape[1], dtype=np.uint64)
+    return np.sum(bits << shifts, axis=1).astype(np.uint64, copy=False)
+
+
+def unpack_boolean_array(arr: np.ndarray, data_len: int) -> npt.NDArray[np.bool_]:
+    """Unpack integer labels into a little-endian boolean bit matrix."""
+
+    packed = np.asarray(arr, dtype=np.uint64).reshape(-1, 1)
+    if data_len < 0:
+        raise ValueError("data_len must be non-negative.")
+    if data_len == 0:
+        return np.zeros((packed.shape[0], 0), dtype=np.bool_)
+    shifts = np.arange(data_len, dtype=np.uint64).reshape(1, -1)
+    return ((packed >> shifts) & 1).astype(np.bool_)
+
+
+def packed_bits_to_int(bits: np.ndarray | Sequence[bool] | Sequence[int]) -> int:
+    """Pack a one-dimensional bit sequence into a Python integer."""
+
+    return int(pack_boolean_array(np.asarray(bits, dtype=np.uint8))[0])
+
+
+def unpack_packed_bits(packed: int, length: int) -> npt.NDArray[np.uint8]:
+    """Unpack a Python integer into a little-endian ``uint8`` bit vector."""
+
+    if length < 0:
+        raise ValueError("length must be non-negative.")
+    if length == 0:
+        return np.zeros(0, dtype=np.uint8)
+    shifts = np.arange(length, dtype=np.uint64)
+    return ((np.uint64(packed) >> shifts) & 1).astype(np.uint8)
+
+
+def shots_to_counts(shots: np.ndarray) -> npt.NDArray[np.int64]:
+    """Convert a boolean shot matrix into a dense little-endian count table."""
+
+    shot_bits = np.asarray(shots, dtype=np.uint8)
+    if shot_bits.ndim != 2:
+        raise ValueError("shots must be a 2D bit array.")
+    packed_shots = pack_boolean_array(shot_bits)
+    return np.bincount(
+        packed_shots.astype(np.int64, copy=False),
+        minlength=1 << shot_bits.shape[1],
+    )
+
+
+def det_obs_shots_to_counts(
+    det_shots: np.ndarray,
+    obs_shots: np.ndarray,
+) -> npt.NDArray[np.int64]:
+    """Convert detector and observable shots into a combined count table."""
+
+    return shots_to_counts(np.concatenate([det_shots, obs_shots], axis=1))
+
+
+def packed_pattern_targets(targets: np.ndarray) -> set[int]:
+    """Pack a target syndrome matrix into an integer lookup set."""
+
+    return {int(x) for x in pack_boolean_array(np.asarray(targets, dtype=np.uint8))}

--- a/test/decoders/test_bit_packing_public.py
+++ b/test/decoders/test_bit_packing_public.py
@@ -1,0 +1,37 @@
+import numpy as np
+
+from bloqade.decoders.bit_packing import (
+    shots_to_counts,
+    pack_boolean_array,
+    packed_bits_to_int,
+    unpack_packed_bits,
+    unpack_boolean_array,
+    det_obs_shots_to_counts,
+)
+
+
+def test_public_bit_packing_helpers_round_trip_little_endian_bits():
+    bits = np.array([[1, 0, 1], [0, 1, 1]], dtype=np.uint8)
+
+    packed = pack_boolean_array(bits)
+
+    assert packed.tolist() == [0b101, 0b110]
+    np.testing.assert_array_equal(unpack_boolean_array(packed, 3), bits.astype(bool))
+    assert packed_bits_to_int([1, 0, 1, 1]) == 0b1101
+    np.testing.assert_array_equal(
+        unpack_packed_bits(0b1101, 4),
+        np.array([1, 0, 1, 1], dtype=np.uint8),
+    )
+
+
+def test_public_count_helpers_pack_detector_observable_shots():
+    det_shots = np.array([[0, 0], [1, 0]], dtype=bool)
+    obs_shots = np.array([[0], [1]], dtype=bool)
+
+    counts = det_obs_shots_to_counts(det_shots, obs_shots)
+
+    expected = np.zeros(8, dtype=np.int64)
+    expected[0] = 1
+    expected[5] = 1
+    np.testing.assert_array_equal(counts, expected)
+    np.testing.assert_array_equal(shots_to_counts(det_shots), np.array([1, 1, 0, 0]))


### PR DESCRIPTION
## Dependencies

Same-repo stack:
- Depends on: none; base is `jasonh/mle-aug`.
- This PR is base for: `codex-msd-decoder-table-confidence`, `codex-msd-decoder-dem-utils`.

Cross-repo dependencies:
- Depends on: none.
- Required for CI: no.

Review status:
- Draft until dependencies are merged/released: no.

## Summary

- Adds public `bloqade.decoders.bit_packing` helpers for packing bit rows and count dictionaries.
- Reuses the public helpers from existing MLD internals.
- Adds focused public API tests.

## Boundary note

- The core MLD APIs still accept ordinary unpacked detector/observable shot arrays; this PR does not make packed shot data part of the user-facing decoder input contract.
- The existing dense `TableDecoder` already uses this little-endian integer convention internally for count-table bins and correction lookup indices.
- Three helpers are mainly exposed for downstream `bloqade-lanes` decoder workflows:
  - `packed_bits_to_int`: used to turn syndrome arrays into stable integer keys for cached decoder calls, since `lru_cache` cannot key directly on `np.ndarray`.
  - `unpack_packed_bits`: used to recover syndrome/correction bit arrays from cached integer keys and by the sparse table decoder when unpacking observable corrections.
  - `packed_pattern_targets`: used to build `set[int]` target-pattern lookups for fast corrected-factory-output membership checks during postselection and MLD score estimation.
- This placement is a little awkward by design: the packing convention belongs to decoder table indexing, but two of the helper call sites are in `bloqade-lanes` workflow/evaluation code. The intent is to avoid duplicating or subtly drifting from the decoder table-key convention in downstream workflows; reviewers should feel free to push back if they prefer keeping the lanes-only conveniences local to `bloqade-lanes` instead.

## Review focus

- Bit ordering and packed integer key semantics.
- Compatibility with existing MLD count-table behavior.
- Whether the downstream convenience helpers should be public here or kept private/local to `bloqade-lanes`.

## Test plan
TODO: add more tests?

- `uv run --index-strategy=unsafe-best-match pytest test/decoders/test_bit_packing_public.py test/decoders/test_table_decoder_public.py test/decoders/test_dem_public.py test/test_imports.py -q` -> `11 passed in 0.68s` on full decoder stack.
- `uv run --index-strategy=unsafe-best-match ruff check src test/decoders/test_bit_packing_public.py test/decoders/test_table_decoder_public.py test/decoders/test_dem_public.py test/test_imports.py` -> passed.
- Note: broader decoder suite may require optional `mwpf` and `tesseract_decoder`.

