### PR TITLE
feat: add sparse table decoder confidence APIs

### DIFF
--- a/src/bloqade/decoders/__init__.py
+++ b/src/bloqade/decoders/__init__.py
@@ -9,6 +9,8 @@ from ._decoders import (
     TesseractDecoder as TesseractDecoder,
     BeliefFindDecoder as BeliefFindDecoder,
     ConfidenceDecoder as ConfidenceDecoder,
+    SparseTableDecoder as SparseTableDecoder,
+    TableDecoderWithConfidence as TableDecoderWithConfidence,
 )
 from .dialects.annotate.types import (
     Detector as Detector,

--- a/src/bloqade/decoders/_decoders/__init__.py
+++ b/src/bloqade/decoders/_decoders/__init__.py
@@ -1,4 +1,4 @@
-from .mld import TableDecoder as TableDecoder
+from .mld import TableDecoder as TableDecoder, SparseTableDecoder as SparseTableDecoder
 from .mle import GurobiDecoder as GurobiDecoder
 from .base import BaseDecoder as BaseDecoder, ConfidenceDecoder as ConfidenceDecoder
 from .ldpc import (
@@ -8,3 +8,4 @@ from .ldpc import (
 )
 from .mwpf import MWPFDecoder as MWPFDecoder
 from .tesseract import TesseractDecoder as TesseractDecoder
+from .confidence import TableDecoderWithConfidence as TableDecoderWithConfidence

--- a/src/bloqade/decoders/_decoders/confidence.py
+++ b/src/bloqade/decoders/_decoders/confidence.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+from bloqade.decoders.bit_packing import pack_boolean_array
+
+from .base import BaseDecoder, ConfidenceDecoder
+
+
+@dataclass(frozen=True)
+class TableDecoderWithConfidence(ConfidenceDecoder):
+    """Wrap a decoder with a syndrome-indexed confidence score."""
+
+    decoder: BaseDecoder
+    syndrome_confidence: np.ndarray
+    confidence_score_mode: str = "mld_output_fidelity"
+
+    def _decode(self, detector_bits: np.ndarray) -> np.ndarray:
+        return np.asarray(self.decoder.decode(detector_bits), dtype=np.bool_)
+
+    def decode_with_confidence(
+        self,
+        detector_bits: np.ndarray,
+    ) -> tuple[np.ndarray, np.float64]:
+        if detector_bits.ndim != 1:
+            raise ValueError(
+                "decode_with_confidence expects a single detector shot (1D array)."
+            )
+        correction = self.decode(detector_bits)
+        packed = int(pack_boolean_array(np.asarray(detector_bits, dtype=np.uint8))[0])
+        score = (
+            float(self.syndrome_confidence[packed])
+            if packed < len(self.syndrome_confidence)
+            else float("nan")
+        )
+        return correction, np.float64(score)

--- a/src/bloqade/decoders/_decoders/mld/__init__.py
+++ b/src/bloqade/decoders/_decoders/mld/__init__.py
@@ -1,1 +1,2 @@
+from .sparse import SparseTableDecoder as SparseTableDecoder
 from .decoder import TableDecoder as TableDecoder

--- a/src/bloqade/decoders/_decoders/mld/sparse.py
+++ b/src/bloqade/decoders/_decoders/mld/sparse.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import stim
+import numpy as np
+
+from bloqade.decoders.bit_packing import (
+    pack_boolean_array,
+    unpack_packed_bits,
+)
+
+from ..base import BaseDecoder
+
+
+class SparseTableDecoder(BaseDecoder):
+    """Sparse lookup-table decoder with dense ``TableDecoder`` argmax semantics."""
+
+    def __init__(
+        self,
+        dem: stim.DetectorErrorModel,
+        det_obs_counts: np.ndarray | None = None,
+    ) -> None:
+        super().__init__(dem)
+        self._dem = dem
+        self._counts_by_detector: dict[int, dict[int, int]] = {}
+        self._maximum_likelihood_correction: dict[int, int] | None = None
+        if det_obs_counts is not None:
+            self._add_dense_counts(det_obs_counts)
+
+    @property
+    def num_detectors(self) -> int:
+        return self._dem.num_detectors
+
+    @property
+    def num_observables(self) -> int:
+        return self._dem.num_observables
+
+    @classmethod
+    def from_det_obs_shots(
+        cls,
+        dem: stim.DetectorErrorModel,
+        det_obs_shots: np.ndarray,
+    ) -> SparseTableDecoder:
+        decoder = cls(dem)
+        decoder.update_det_obs_counts(det_obs_shots)
+        return decoder
+
+    def _add_dense_counts(self, det_obs_counts: np.ndarray) -> None:
+        dense = np.asarray(det_obs_counts)
+        expected_len = 1 << (self.num_detectors + self.num_observables)
+        if dense.shape != (expected_len,):
+            raise ValueError(
+                f"det_obs_counts must have shape ({expected_len},), got {dense.shape}"
+            )
+
+        det_mask = (1 << self.num_detectors) - 1
+        for packed in np.flatnonzero(dense).tolist():
+            det = int(packed) & det_mask
+            obs = int(packed) >> self.num_detectors
+            detector_counts = self._counts_by_detector.setdefault(det, {})
+            detector_counts[obs] = detector_counts.get(obs, 0) + int(dense[packed])
+
+    def update_det_obs_counts(self, det_obs_shots: np.ndarray) -> None:
+        shots = np.asarray(det_obs_shots, dtype=np.uint8)
+        expected_width = self.num_detectors + self.num_observables
+        if shots.ndim != 2 or shots.shape[1] != expected_width:
+            raise ValueError(
+                f"Expected det_obs_shots with shape (N, {expected_width}), "
+                f"got {shots.shape}"
+            )
+
+        packed_det = pack_boolean_array(shots[:, : self.num_detectors])
+        if self.num_observables:
+            packed_obs = pack_boolean_array(shots[:, self.num_detectors :])
+        else:
+            packed_obs = np.zeros(len(shots), dtype=np.uint64)
+
+        pairs = np.column_stack([packed_det, packed_obs])
+        unique_pairs, counts = np.unique(pairs, axis=0, return_counts=True)
+        for row, count in zip(unique_pairs, counts, strict=True):
+            det = int(row[0])
+            obs = int(row[1])
+            detector_counts = self._counts_by_detector.setdefault(det, {})
+            detector_counts[obs] = detector_counts.get(obs, 0) + int(count)
+        self._maximum_likelihood_correction = None
+
+    def cache_correction(self) -> None:
+        if self._maximum_likelihood_correction is not None:
+            return
+        correction: dict[int, int] = {}
+        for det, obs_counts in self._counts_by_detector.items():
+            best_obs = 0
+            best_count = -1
+            for obs, count in obs_counts.items():
+                if count > best_count or (count == best_count and obs < best_obs):
+                    best_obs = int(obs)
+                    best_count = int(count)
+            correction[det] = best_obs
+        self._maximum_likelihood_correction = correction
+
+    def _decode(self, detector_bits: np.ndarray) -> np.ndarray:
+        self.cache_correction()
+        assert self._maximum_likelihood_correction is not None
+        packed = int(pack_boolean_array(np.asarray(detector_bits, dtype=np.uint8))[0])
+        obs = self._maximum_likelihood_correction.get(packed, 0)
+        return unpack_packed_bits(obs, self.num_observables).astype(np.bool_)

--- a/test/decoders/test_table_decoder_public.py
+++ b/test/decoders/test_table_decoder_public.py
@@ -1,0 +1,40 @@
+import stim
+import numpy as np
+
+from bloqade.decoders import SparseTableDecoder, TableDecoderWithConfidence
+
+
+def test_sparse_table_decoder_matches_dense_mld_argmax_semantics():
+    dem = stim.DetectorErrorModel("error(0.5) D0 L0\nerror(0.5) D1 L0\n")
+    shots = np.array(
+        [
+            [0, 0, 0],
+            [0, 1, 1],
+            [0, 1, 1],
+            [1, 0, 1],
+            [1, 1, 0],
+        ],
+        dtype=bool,
+    )
+    decoder = SparseTableDecoder.from_det_obs_shots(dem, shots)
+
+    decoded = decoder.decode(np.array([[0, 0], [0, 1], [1, 0], [1, 1]]))
+
+    np.testing.assert_array_equal(decoded, np.array([[0], [1], [1], [0]], dtype=bool))
+
+
+def test_table_decoder_with_confidence_uses_packed_syndrome_scores():
+    dem = stim.DetectorErrorModel("error(0.5) D0 L0\n")
+    decoder = SparseTableDecoder.from_det_obs_shots(
+        dem,
+        np.array([[0, 0], [1, 1], [1, 1]], dtype=bool),
+    )
+    wrapped = TableDecoderWithConfidence(
+        decoder=decoder,
+        syndrome_confidence=np.array([0.25, 0.75], dtype=np.float64),
+    )
+
+    correction, confidence = wrapped.decode_with_confidence(np.array([1], dtype=bool))
+
+    np.testing.assert_array_equal(correction, np.array([True]))
+    assert confidence == np.float64(0.75)


### PR DESCRIPTION
## Dependencies

Same-repo stack:
- Depends on: #35 because this branch imports the promoted public bit-packing helpers.
- Code dependency note: the sparse/confidence decoder concepts are not inherently tied to #35; they could use the old private MLD utility location if reviewers prefer decoupling these PRs (however, you would have to define the "unpack_boolean_array" function that is used by SparseTableDecoder).
- This PR is base for: `codex-msd-decoder-dem-utils`.

Cross-repo dependencies:
- Depends on: none.
- Required for CI: no.

Review status:
- Draft until dependencies are merged/released: no.

## Summary

- Adds `SparseTableDecoder`.
- Adds `TableDecoderWithConfidence`.
- Exports the new decoder APIs from `bloqade.decoders`.

## Motivation

- `SparseTableDecoder` is an experimental table-decoder implementation used from the `bloqade-lanes` notebooks to test whether sparse storage/lookup is faster for very large MLD tables.
- `TableDecoderWithConfidence` exposes a table-decoder wrapper that implements the `ConfidenceDecoder` interface.
- The confidence wrapper is intended for downstream `bloqade-lanes` postprocessing/analysis, where we need both the decoded correction and a syndrome-indexed confidence score to evaluate and plot decoder curves.

## Review focus

- Sparse table lookup behavior for missing syndromes.
- Whether `SparseTableDecoder` is acceptable as an experimental public API, or should be marked/named more cautiously.
- Confidence wrapper return shape and fallback behavior.

## Test plan

- `uv run --index-strategy=unsafe-best-match pytest test/decoders/test_bit_packing_public.py test/decoders/test_table_decoder_public.py test/decoders/test_dem_public.py test/test_imports.py -q` -> `11 passed in 0.68s` on full decoder stack.
- `uv run --index-strategy=unsafe-best-match ruff check src test/decoders/test_bit_packing_public.py test/decoders/test_table_decoder_public.py test/decoders/test_dem_public.py test/test_imports.py` -> passed.
- Note: broader decoder suite may require optional `mwpf` and `tesseract_decoder`.
