### PR TITLE
feat: add detector error model utilities

### DIFF
--- a/src/bloqade/decoders/dem.py
+++ b/src/bloqade/decoders/dem.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from typing import Protocol
+
+import stim
+import numpy as np
+import numpy.typing as npt
+from beliefmatching import detector_error_model_to_check_matrices
+
+
+class DetectorErrorModelTask(Protocol):
+    """Protocol for objects exposing a Stim detector error model."""
+
+    @property
+    def detector_error_model(self) -> stim.DetectorErrorModel: ...
+
+
+def make_layout_only_dem(
+    num_detectors: int,
+    num_observables: int,
+) -> stim.DetectorErrorModel:
+    """Create a minimal DEM carrying detector and observable dimensions."""
+
+    terms: list[str] = []
+    if num_detectors:
+        terms.append(" ".join(f"D{i}" for i in range(int(num_detectors))))
+    if num_observables:
+        terms.append(" ".join(f"L{i}" for i in range(int(num_observables))))
+    if not terms:
+        raise ValueError("Need at least one detector or observable.")
+    return stim.DetectorErrorModel("\n".join(f"error(0.5) {term}" for term in terms))
+
+
+def matrix_to_dem(
+    check_matrix: np.ndarray,
+    observables_matrix: np.ndarray,
+    priors: np.ndarray,
+) -> stim.DetectorErrorModel:
+    """Convert binary detector/observable matrices into a Stim DEM."""
+
+    check = np.asarray(check_matrix, dtype=np.uint8)
+    observables = np.asarray(observables_matrix, dtype=np.uint8)
+    prior_arr = np.asarray(priors, dtype=np.float64)
+    if check.ndim != 2 or observables.ndim != 2:
+        raise ValueError("check_matrix and observables_matrix must be 2D.")
+    if check.shape[1] != observables.shape[1] or check.shape[1] != len(prior_arr):
+        raise ValueError("Matrices and priors must describe the same errors.")
+
+    lines: list[str] = []
+    for col, prior in enumerate(prior_arr):
+        det_targets = [f"D{i}" for i in np.flatnonzero(check[:, col])]
+        obs_targets = [f"L{i}" for i in np.flatnonzero(observables[:, col])]
+        if not det_targets and not obs_targets:
+            continue
+        safe_prior = float(np.clip(prior, 1e-12, 1.0 - 1e-12))
+        lines.append(f"error({safe_prior:.16g}) " + " ".join(det_targets + obs_targets))
+    if not lines:
+        raise ValueError("Matrix reduction produced an empty DEM.")
+    return stim.DetectorErrorModel("\n".join(lines))
+
+
+def detector_error_model_matrices(
+    task_or_dem: DetectorErrorModelTask | stim.DetectorErrorModel,
+) -> dict[str, npt.NDArray[np.float64] | npt.NDArray[np.int64]]:
+    """Extract check matrices, observable matrices, and priors from a DEM."""
+
+    dem = (
+        task_or_dem
+        if isinstance(task_or_dem, stim.DetectorErrorModel)
+        else task_or_dem.detector_error_model
+    )
+    dem_matrix = detector_error_model_to_check_matrices(
+        dem,
+        allow_undecomposed_hyperedges=True,
+    )
+    return {
+        "H": dem_matrix.check_matrix.toarray().astype(np.int64),
+        "O": dem_matrix.observables_matrix.toarray().astype(np.int64),
+        "priors": np.asarray(dem_matrix.priors, dtype=np.float64),
+    }

--- a/test/decoders/test_dem_public.py
+++ b/test/decoders/test_dem_public.py
@@ -1,0 +1,19 @@
+import numpy as np
+
+from bloqade.decoders.dem import matrix_to_dem, make_layout_only_dem
+
+
+def test_dem_helpers_create_layout_only_and_matrix_dems():
+    layout_dem = make_layout_only_dem(num_detectors=2, num_observables=1)
+    assert layout_dem.num_detectors == 2
+    assert layout_dem.num_observables == 1
+
+    dem = matrix_to_dem(
+        check_matrix=np.array([[1, 0], [0, 1]], dtype=np.uint8),
+        observables_matrix=np.array([[1, 0]], dtype=np.uint8),
+        priors=np.array([0.25, 0.5], dtype=np.float64),
+    )
+
+    assert dem.num_detectors == 2
+    assert dem.num_observables == 1
+    assert "D0 L0" in str(dem)


### PR DESCRIPTION
## Dependencies

Same-repo stack:
- Merge order: intended to merge after #36 because the branches are stacked for review order.
- Code dependency: none on #36; these DEM helpers are independent of the sparse/confidence decoder APIs and could be rebased directly onto `jasonh/mle-aug` if needed.
- This PR is base for: lanes decoder-construction PRs.

Cross-repo dependencies:
- Depends on: none.
- Required for CI: no.

Review status:
- Draft until dependencies are merged/released: no.

## Summary

- Adds public DEM utilities for layout-only detector error models.
- Adds matrix-to-DEM conversion helpers used by downstream MLE/MLD construction.
- `make_layout_only_dem` is used as convenience functions for constructing the `TableDecoder`: currently, `TableDecoder` takes in a `stim.DetectorErrorModel`; however, the TableDecoder doesn't really need the DEM, it just needs the number of detectors and observables (as it relies on sampling from the task a bunch to construct the table decoder). 
- `matrix_to_dem` and `detector_error_model_matrices` are used for the particular use case where you want to take a "subset" of detectors/observables from the DEM. This use case can be found in bloqade-lanes (where we want separate decoders for the "full decoder" used to decode the output qubit, and the "factory decoder" used to decode the ancilla qubits used for postselection in MSD).

## Review focus

- DEM detector/observable indexing.
- Matrix shape validation and conversion semantics.
- Whether reviewers prefer this PR to stay stacked for merge order or be rebased independently.

## Test plan

- `uv run --index-strategy=unsafe-best-match pytest test/decoders/test_bit_packing_public.py test/decoders/test_table_decoder_public.py test/decoders/test_dem_public.py test/test_imports.py -q` -> `11 passed in 0.68s` on full decoder stack.
- `uv run --index-strategy=unsafe-best-match ruff check src test/decoders/test_bit_packing_public.py test/decoders/test_table_decoder_public.py test/decoders/test_dem_public.py test/test_imports.py` -> passed.
- Note: broader decoder suite may require optional `mwpf` and `tesseract_decoder`.
