### PR TITLE
Add Python 3.13 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v7
@@ -30,10 +30,10 @@ jobs:
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}
       - name: Install the project
-        run: uv sync --dev --all-extras
+        run: uv sync --python ${{ matrix.python-version }} --locked --dev --all-extras
       - name: Run tests
         # For example, using `pytest`
-        run: uv run just coverage
+        run: uv run --locked just coverage
       - name: Upload Coverage to Codecov
         uses: codecov/codecov-action@v7
         with:


### PR DESCRIPTION
Adding python 3.13 to CI; 3.14 is not added because it is not supported by tesseract yet.

Making the CI test command a bit more explicit, to avoid mismatched versions or re-resolves.