### PR TITLE
Fix #47: Report zero confidence for unsupported corrections

### DIFF
--- a/src/bloqade/decoders/_decoders/mld/decoder.py
+++ b/src/bloqade/decoders/_decoders/mld/decoder.py
@@ -159,9 +159,16 @@ class TableDecoder(BaseDecoder):
     ) -> tuple[npt.NDArray[np.bool_], float | npt.NDArray[np.float64]]:
         """Decode detector bits with the default confidence score."""
         result = self.decode(detector_bits)
+        counts_by_observable_and_syndrome = self._det_obs_counts.reshape(
+            2**self.num_observables, 2**self.num_detectors
+        )
+        packed = pack_boolean_array(detector_bits.reshape(-1, self.num_detectors))
+        confidence = (
+            counts_by_observable_and_syndrome[:, packed].sum(axis=0) > 0
+        ).astype(np.float64)
         if detector_bits.ndim == 1:
-            return result, 1.0
-        return result, np.ones(len(detector_bits), dtype=np.float64)
+            return result, float(confidence[0])
+        return result, confidence
 
     def decode_det_obs_counts(self, raw_det_obs_counts: np.ndarray) -> np.ndarray:
         """Decode raw detector-observable counts.

--- a/src/bloqade/decoders/_decoders/mle/decoder.py
+++ b/src/bloqade/decoders/_decoders/mle/decoder.py
@@ -142,7 +142,9 @@ class GurobiDecoder(BaseDecoder):
     def weight_from_error(self, error: np.ndarray) -> np.ndarray:
         return np.sum(error * self._weights, axis=1)
 
-    def _decode_error(self, det_shots: np.ndarray) -> np.ndarray:
+    def _decode_error(
+        self, det_shots: np.ndarray, confidence: np.ndarray | None = None
+    ) -> np.ndarray:
         import gurobipy as gp
         from gurobipy import GRB
 
@@ -192,9 +194,9 @@ class GurobiDecoder(BaseDecoder):
                 if self._verbose:
                     print("Did not find optimal solution", m.status)
                 m.close()
-                raise RuntimeError(
-                    f"Gurobi did not find an optimal solution. Status: {m.status}"
-                )
+                if confidence is not None:
+                    confidence[d] = 0.0
+                continue
             error = np.round(
                 np.array([e.X for e in error_variables]), decimals=0
             ).astype(bool)
@@ -215,25 +217,35 @@ class GurobiDecoder(BaseDecoder):
                     ) % 2
         return logicals.astype(bool)
 
+    def _decode_batch(
+        self, detector_bits: npt.NDArray[np.bool_]
+    ) -> tuple[npt.NDArray[np.bool_], npt.NDArray[np.float64]]:
+        confidence = np.ones(len(detector_bits), dtype=np.float64)
+        errors = self._decode_error(detector_bits, confidence)
+        result = self.logical_from_error(errors)
+        result[confidence == 0.0] = False
+        return result, confidence
+
     def _decode(self, detector_bits: npt.NDArray[np.bool_]) -> npt.NDArray[np.bool_]:
         """Decode a single shot of detector bits."""
-        det_2d = detector_bits.reshape(1, -1)
-        errors = self._decode_error(det_2d)
-        obs = self.logical_from_error(errors)
-        return obs[0].astype(np.bool_)
+        result, _ = self._decode_batch(detector_bits.reshape(1, -1))
+        return result[0]
 
     def decode(self, detector_bits: npt.NDArray[np.bool_]) -> npt.NDArray[np.bool_]:
         """Decode a batch or single shot of detector bits."""
         if detector_bits.ndim == 1:
             return self._decode(detector_bits)
-        errors = self._decode_error(detector_bits)
-        return self.logical_from_error(errors)
+        result, _ = self._decode_batch(detector_bits)
+        return result
 
     def decode_confidence(
         self, detector_bits: npt.NDArray[np.bool_]
     ) -> tuple[npt.NDArray[np.bool_], float | npt.NDArray[np.float64]]:
         """Decode detector bits with the default confidence score."""
-        result = self.decode(detector_bits)
-        if detector_bits.ndim == 1:
-            return result, 1.0
-        return result, np.ones(len(detector_bits), dtype=np.float64)
+        is_single_shot = detector_bits.ndim == 1
+        result, confidence = self._decode_batch(
+            detector_bits.reshape(1, -1) if is_single_shot else detector_bits
+        )
+        if is_single_shot:
+            return result[0], float(confidence[0])
+        return result, confidence

--- a/test/decoders/test_mld.py
+++ b/test/decoders/test_mld.py
@@ -153,6 +153,23 @@ def test_single_shot_decode_confidence():
     np.testing.assert_array_equal(result, np.array([True]))
 
 
+def test_unseen_syndrome_has_zero_confidence():
+    dem = stim.DetectorErrorModel("error(0.1) D0 L0\nerror(0.1) D1 L0\n")
+    decoder = _trained_decoder_from_counts(dem, np.array([1, 0, 0, 0, 0, 1, 0, 0]))
+
+    result, confidence = decoder.decode_confidence(
+        np.array([[0, 0], [1, 0], [0, 1]], dtype=bool)
+    )
+
+    np.testing.assert_array_equal(result, np.array([[False], [True], [False]]))
+    np.testing.assert_array_equal(confidence, np.array([1.0, 1.0, 0.0]))
+
+    result, confidence = decoder.decode_confidence(np.array([0, 1], dtype=bool))
+
+    np.testing.assert_array_equal(result, np.array([False]))
+    assert confidence == 0.0
+
+
 def test_table_decoder_can_instantiate_without_training():
     decoder = TableDecoder.instantiate(simple_dem())
 

--- a/test/decoders/test_mle.py
+++ b/test/decoders/test_mle.py
@@ -1,4 +1,5 @@
 import math
+from unittest.mock import Mock
 
 import stim
 import numpy as np
@@ -135,6 +136,30 @@ def test_single_shot_decode_confidence():
 
     assert confidence == 1.0
     np.testing.assert_array_equal(result, np.array([True]))
+
+
+def test_nonoptimal_status_has_zero_confidence(monkeypatch):
+    import gurobipy as gp
+    from gurobipy import GRB
+
+    decoder = GurobiDecoder(stim.DetectorErrorModel("error(0) L0"))
+    models = [Mock(status=GRB.INFEASIBLE), Mock(status=GRB.OPTIMAL)]
+    monkeypatch.setattr(gp, "Model", Mock(side_effect=models))
+    monkeypatch.setattr(gp, "Env", Mock(return_value=Mock()))
+    monkeypatch.setattr(GurobiDecoder, "_env", None)
+
+    result, confidence = decoder.decode_confidence(np.empty((2, 0), dtype=bool))
+
+    np.testing.assert_array_equal(result, np.array([[False], [False]]))
+    np.testing.assert_array_equal(confidence, np.array([0.0, 1.0]))
+
+    monkeypatch.setattr(gp, "Model", Mock(return_value=Mock(status=GRB.INFEASIBLE)))
+    np.testing.assert_array_equal(decoder.decode(np.empty(0, dtype=bool)), [False])
+
+    result, confidence = decoder.decode_confidence(np.empty(0, dtype=bool))
+
+    np.testing.assert_array_equal(result, np.array([False]))
+    assert confidence == 0.0
 
 
 # --- SinterGurobiDecoder tests ---


### PR DESCRIPTION
AI generated. Manually vetted, see my comments in the thread below.

Prompt:

> Address issue https://github.com/QuEraComputing/bloqade-decoders/issues/47 in a new PR. Set it up as two commits, one for each concerned decoders. Make the changes be as minimal as possible, prioritize simplicity and having a minimal diff. Update changelog and agents files if you deem that necessary. In the PR description only state that this is AI generated, post this prompt and the details of what agent prepared the PR.

Agent details:

Prepared by OpenAI Codex, an agent based on GPT-5.