### PR TITLE
Add confidence implementations for MLD and MLE decoders

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,9 +17,9 @@ repos:
   rev: 26.3.1
   hooks:
     - id: black
-- repo: https://github.com/charliermarsh/ruff-pre-commit
+- repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: "v0.15.7"
+  rev: "v0.16.0"
   hooks:
     - id: ruff
       name: ruff (lint)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,19 @@ exclude = [
 
 [tool.ruff.lint]
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+ignore = [
+    # Import ordering is owned by the dedicated isort pre-commit hook (profile
+    # black); leaving it to ruff too would make the two tools fight.
+    "I001",
+    # `from x import y as y` is the explicit re-export idiom pyright requires;
+    # ruff would otherwise strip the alias and break re-export detection.
+    "PLC0414",
+    # PLR0402's autofix rewrites `import pkg.sub as sub` to `from pkg import
+    # sub`, which is NOT equivalent here: the former guarantees the submodule,
+    # the latter resolves via pkg/__init__ and makes pyright lose the
+    # submodule's types (breaks squin/gemini attribute typing).
+    "PLR0402",
+]
 
 [tool.coverage.run]
 include = ["src/bloqade/*"]

--- a/src/bloqade/decoders/_decoders/base.py
+++ b/src/bloqade/decoders/_decoders/base.py
@@ -77,6 +77,10 @@ class BaseDecoder(ABC):
     ) -> tuple[npt.NDArray[np.bool_], float | npt.NDArray[np.float64]]:
         """Decode a batch or single shot of detector bits with confidence scores.
 
+        Confidence scores are decoder-specific. They are not necessarily
+        probabilities or bounded to a common range, so confidence thresholds
+        should not be shared across decoder types without calibration.
+
         Confidence is ``0.0`` when a decoder did not converge. This default
         implementation always reports ``1.0`` because it has no convergence
         signal.

--- a/src/bloqade/decoders/_decoders/base.py
+++ b/src/bloqade/decoders/_decoders/base.py
@@ -4,6 +4,7 @@ from typing import Any, TypeVar
 import stim
 import numpy as np
 import numpy.typing as npt
+from typing_extensions import Self
 
 DecoderT = TypeVar("DecoderT", bound="BaseDecoder")
 
@@ -15,9 +16,7 @@ class BaseDecoder(ABC):
         self.train(**kwargs)
 
     @classmethod
-    def instantiate(
-        cls: type[DecoderT], dem: stim.DetectorErrorModel, **kwargs: Any
-    ) -> DecoderT:
+    def instantiate(cls, dem: stim.DetectorErrorModel, **kwargs: Any) -> Self:
         """Configure an untrained decoder from constructor keyword arguments."""
         decoder = cls.__new__(cls)
         decoder.dem = dem
@@ -26,7 +25,6 @@ class BaseDecoder(ABC):
 
     def _instantiate(self, **kwargs: Any) -> None:
         """Configure the decoder from constructor keyword arguments."""
-        pass
 
     @property
     def num_detectors(self) -> int:
@@ -41,12 +39,10 @@ class BaseDecoder(ABC):
 
         The default is a no-op for decoders that do not need training.
         """
-        pass
 
     @abstractmethod
     def _decode(self, detector_bits: npt.NDArray[np.bool_]) -> npt.NDArray[np.bool_]:
         """Decode a single shot of detector bits."""
-        pass
 
     def decode(self, detector_bits: npt.NDArray[np.bool_]) -> npt.NDArray[np.bool_]:
         """Decode a batch or single shot of detector bits.

--- a/src/bloqade/decoders/_decoders/mld/decoder.py
+++ b/src/bloqade/decoders/_decoders/mld/decoder.py
@@ -127,6 +127,16 @@ class TableDecoder(BaseDecoder):
             self._maximum_likelihood_correction = np.argmax(obs_counts, axis=0).reshape(
                 -1
             )
+            max_counts = np.max(obs_counts, axis=0).astype(np.float64, copy=False)
+            total_counts = np.sum(obs_counts, axis=0, dtype=np.uint64)
+            confidence = np.zeros(total_counts.shape, dtype=np.float64)
+            np.divide(
+                max_counts,
+                total_counts.astype(np.float64, copy=False),
+                out=confidence,
+                where=total_counts > 0,
+            )
+            self._correction_confidence = confidence
             self._is_cached_correction = True
 
     def _decode(self, detector_bits: npt.NDArray[np.bool_]) -> npt.NDArray[np.bool_]:
@@ -157,15 +167,21 @@ class TableDecoder(BaseDecoder):
     def decode_confidence(
         self, detector_bits: npt.NDArray[np.bool_]
     ) -> tuple[npt.NDArray[np.bool_], float | npt.NDArray[np.float64]]:
-        """Decode detector bits with the default confidence score."""
+        """Decode detector bits with empirical correction confidence.
+
+        For each detector syndrome, the confidence is the sampled count of its
+        most likely observable correction divided by the total sampled count
+        for that syndrome. It is in ``[0.0, 1.0]`` and is ``0.0`` for an unseen
+        syndrome.
+
+        This empirical fraction is not on the same scale as
+        :class:`GurobiDecoder`'s normalized logical-gap confidence, even though
+        both are in ``[0.0, 1.0]``. Confidence thresholds are therefore not
+        interchangeable between the MLD and MLE decoders without calibration.
+        """
         result = self.decode(detector_bits)
-        counts_by_observable_and_syndrome = self._det_obs_counts.reshape(
-            2**self.num_observables, 2**self.num_detectors
-        )
         packed = pack_boolean_array(detector_bits.reshape(-1, self.num_detectors))
-        confidence = (
-            counts_by_observable_and_syndrome[:, packed].sum(axis=0) > 0
-        ).astype(np.float64)
+        confidence = self._correction_confidence[packed]
         if detector_bits.ndim == 1:
             return result, float(confidence[0])
         return result, confidence

--- a/src/bloqade/decoders/_decoders/mld/decoder.py
+++ b/src/bloqade/decoders/_decoders/mld/decoder.py
@@ -159,9 +159,16 @@ class TableDecoder(BaseDecoder):
     ) -> tuple[npt.NDArray[np.bool_], float | npt.NDArray[np.float64]]:
         """Decode detector bits with the default confidence score."""
         result = self.decode(detector_bits)
+        counts_by_observable_and_syndrome = self._det_obs_counts.reshape(
+            2**self.num_observables, 2**self.num_detectors
+        )
+        packed = pack_boolean_array(detector_bits.reshape(-1, self.num_detectors))
+        confidence = (
+            counts_by_observable_and_syndrome[:, packed].sum(axis=0) > 0
+        ).astype(np.float64)
         if detector_bits.ndim == 1:
-            return result, 1.0
-        return result, np.ones(len(detector_bits), dtype=np.float64)
+            return result, float(confidence[0])
+        return result, confidence
 
     def decode_det_obs_counts(self, raw_det_obs_counts: np.ndarray) -> np.ndarray:
         """Decode raw detector-observable counts.

--- a/src/bloqade/decoders/_decoders/mld/decoder.py
+++ b/src/bloqade/decoders/_decoders/mld/decoder.py
@@ -178,6 +178,10 @@ class TableDecoder(BaseDecoder):
         :class:`GurobiDecoder`'s normalized logical-gap confidence, even though
         both are in ``[0.0, 1.0]``. Confidence thresholds are therefore not
         interchangeable between the MLD and MLE decoders without calibration.
+
+        A simple alternative to using the confidence of each decoder would be to sort
+        the results of various decoders by confidence, and subsequently do thresholding
+        based on the accepted fraction of shots instead of by the raw confidence threshold value.
         """
         result = self.decode(detector_bits)
         packed = pack_boolean_array(detector_bits.reshape(-1, self.num_detectors))

--- a/src/bloqade/decoders/_decoders/mle/decoder.py
+++ b/src/bloqade/decoders/_decoders/mle/decoder.py
@@ -39,7 +39,7 @@ class GurobiDecoder(BaseDecoder):
             ) from e
 
         try:
-            import scipy.sparse  # noqa: F401
+            import scipy.sparse
         except ImportError as e:
             raise ImportError(
                 "The scipy package is required for GurobiDecoder. "
@@ -64,7 +64,7 @@ class GurobiDecoder(BaseDecoder):
 
         for instruction in self._flat_dem:  # type: ignore[union-attr]
             if not isinstance(instruction, DemInstruction):
-                raise Exception(
+                raise TypeError(
                     "The detector-error model should be already flattened. But still got DemRepeatBlock."
                 )
             if instruction.type != "error":
@@ -81,8 +81,7 @@ class GurobiDecoder(BaseDecoder):
                     det_targets.append(target.val)
                 else:
                     obs_targets.append(target.val)
-                    if target.val > max_observable_index:
-                        max_observable_index = target.val
+                    max_observable_index = max(max_observable_index, target.val)
 
             if probability == 1:
                 # Certain errors always fire: pre-apply their contributions

--- a/src/bloqade/decoders/_decoders/mle/decoder.py
+++ b/src/bloqade/decoders/_decoders/mle/decoder.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, ClassVar, cast
+from typing import TYPE_CHECKING, Any, ClassVar, NamedTuple, cast
 
 import stim
 import numpy as np
@@ -28,6 +28,11 @@ class GurobiDecoder(BaseDecoder):
     """
 
     _env: ClassVar[GurobiEnv | None] = None
+
+    class _ConfidenceSolveResult(NamedTuple):
+        error: np.ndarray
+        logical: np.ndarray
+        objective: float
 
     def _instantiate(self, verbose: bool = False, **_kwargs: Any) -> None:
         try:
@@ -121,6 +126,14 @@ class GurobiDecoder(BaseDecoder):
         self._observable_indices = observable_indices
         self._certain_det_flip = certain_det_flip
         self._certain_obs_flip = certain_obs_flip
+
+    @classmethod
+    def _get_env(cls) -> object:
+        import gurobipy as gp
+
+        if cls._env is None:
+            cls._env = gp.Env()
+        return cls._env
 
     @staticmethod
     def _check_no_separators(dem: stim.DetectorErrorModel) -> None:
@@ -238,14 +251,195 @@ class GurobiDecoder(BaseDecoder):
         result, _ = self._decode_batch(detector_bits)
         return result
 
+    def _solve_single_shot_for_confidence(
+        self,
+        detector_shot: np.ndarray,
+        *,
+        verbose: bool = False,
+        forbidden_logical: np.ndarray | None = None,
+    ) -> tuple[_ConfidenceSolveResult | None, bool]:
+        import gurobipy as gp
+
+        GRB = gp.GRB
+
+        env = cast(Any, self._get_env())
+        env.setParam("OutputFlag", 1 if verbose else 0)  # type: ignore[union-attr]
+
+        m = gp.Model("mip1", env=env)
+        weights = self._weights
+        detector_vertices = self._detector_vertices
+        observable_indices = self._observable_indices
+
+        error_variables: list["gp.Var"] = []
+        detector_variables: list["gp.Var"] = []
+        logical_variables: list["gp.Var"] = []
+        objective: gp.LinExpr = gp.LinExpr(0)
+
+        for i, weight in enumerate(weights):
+            error_variables.append(m.addVar(vtype=GRB.BINARY, name="e" + str(i)))
+            objective += weight * error_variables[i]
+        m.setObjective(objective, GRB.MAXIMIZE)
+
+        detector_shot = np.asarray(detector_shot, dtype=int) ^ self._certain_det_flip
+        for i, detector_vertex in enumerate(detector_vertices):
+            detector_variables.append(
+                m.addVar(
+                    vtype=GRB.INTEGER,
+                    name="h" + str(i),
+                    ub=len(detector_vertex),
+                    lb=0,
+                )
+            )
+            constraint: gp.LinExpr = gp.LinExpr(0)
+            for j in detector_vertex:
+                constraint += error_variables[j]
+            constraint -= 2 * detector_variables[i]
+            m.addConstr(constraint == int(detector_shot[i]), name="c" + str(i))
+
+        for obs_idx, observable_index in enumerate(observable_indices):
+            logical_var = m.addVar(vtype=GRB.BINARY, name="l" + str(obs_idx))
+            logical_variables.append(logical_var)
+            certain_flip = int(self._certain_obs_flip[obs_idx])
+            if len(observable_index) == 0:
+                m.addConstr(
+                    logical_var == certain_flip,
+                    name="lfix" + str(obs_idx),
+                )
+                continue
+            slack_var = m.addVar(
+                vtype=GRB.INTEGER,
+                lb=0,
+                ub=len(observable_index),
+                name="u" + str(obs_idx),
+            )
+            constraint = gp.LinExpr(certain_flip)
+            for j in observable_index:
+                constraint += error_variables[j]
+            constraint -= 2 * slack_var
+            m.addConstr(constraint == logical_var, name="lpar" + str(obs_idx))
+
+        if forbidden_logical is not None:
+            diff_variables: list["gp.Var"] = []
+            for obs_idx, forbidden_bit in enumerate(forbidden_logical.astype(int)):
+                diff_var = m.addVar(vtype=GRB.BINARY, name="d" + str(obs_idx))
+                diff_variables.append(diff_var)
+                if forbidden_bit:
+                    m.addConstr(
+                        diff_var + logical_variables[obs_idx] == 1,
+                        name="ddiff" + str(obs_idx),
+                    )
+                else:
+                    m.addConstr(
+                        diff_var == logical_variables[obs_idx],
+                        name="ddiff" + str(obs_idx),
+                    )
+            m.addConstr(gp.quicksum(diff_variables) >= 1, name="logical_difference")
+
+        m.optimize()
+        status = m.status
+        if status == GRB.INFEASIBLE and forbidden_logical is not None:
+            m.close()
+            return None, True
+        if status != GRB.OPTIMAL:
+            if verbose:
+                print("Did not find optimal solution", status)
+            m.close()
+            return None, False
+
+        error = np.round(
+            np.array([var.X for var in error_variables]), decimals=0
+        ).astype(bool)
+        logical = np.round(
+            np.array([var.X for var in logical_variables]), decimals=0
+        ).astype(bool)
+        objective_value = float(m.ObjVal)
+        m.close()
+        return (
+            self._ConfidenceSolveResult(
+                error=error,
+                logical=logical,
+                objective=objective_value,
+            ),
+            True,
+        )
+
+    def _decode_with_logical_gap(
+        self,
+        detector_bits: npt.NDArray[np.bool_],
+        verbose: bool = False,
+    ) -> tuple[npt.NDArray[np.bool_], np.ndarray]:
+        """Decode detector bits and return the logical-gap confidence score."""
+
+        single_shot = detector_bits.ndim == 1
+        det_shots = detector_bits.reshape(1, -1) if single_shot else detector_bits
+
+        decoded_obs = np.zeros(
+            (det_shots.shape[0], self.num_observables),
+            dtype=np.bool_,
+        )
+        logical_gaps = np.zeros(det_shots.shape[0], dtype=float)
+
+        for shot_idx, detector_shot in enumerate(det_shots.astype(int)):
+            best, best_converged = self._solve_single_shot_for_confidence(
+                detector_shot,
+                verbose=verbose,
+            )
+            if not best_converged:
+                continue
+            assert best is not None
+            second, second_converged = self._solve_single_shot_for_confidence(
+                detector_shot,
+                verbose=verbose,
+                forbidden_logical=best.logical,
+            )
+            if not second_converged:
+                continue
+            decoded_obs[shot_idx] = best.logical
+            logical_gaps[shot_idx] = (
+                np.inf if second is None else best.objective - second.objective
+            )
+
+        if single_shot:
+            return decoded_obs[0], logical_gaps
+        return decoded_obs, logical_gaps
+
     def decode_confidence(
         self, detector_bits: npt.NDArray[np.bool_]
     ) -> tuple[npt.NDArray[np.bool_], float | npt.NDArray[np.float64]]:
-        """Decode detector bits with the default confidence score."""
-        is_single_shot = detector_bits.ndim == 1
-        result, confidence = self._decode_batch(
-            detector_bits.reshape(1, -1) if is_single_shot else detector_bits
+        """Decode detector bits and return normalized logical-gap confidence.
+
+        For a detector syndrome, let ``best`` be the most likely error
+        configuration and ``alternative`` be the most likely configuration
+        with a different logical correction. First compute the logical gap
+
+        ``log(P(best) / P(alternative))``,
+
+        as the difference between their Gurobi objective values. The returned
+        confidence is ``tanh(logical_gap / 2)``, a normalized likelihood margin
+        in ``[0.0, 1.0]``. It is ``1.0`` when no alternative logical correction
+        is feasible and ``0.0`` when the alternatives are equally likely or
+        either optimization does not find an optimal solution.
+
+        This normalized margin is not a calibrated probability and is not on
+        the same scale as :class:`TableDecoder`'s empirical confidence.
+        Confidence thresholds are therefore not interchangeable between the
+        MLE and MLD decoders without calibration.
+
+        A single detector shot returns one correction and a scalar confidence.
+        A batch returns corrections with shape ``(shots, num_observables)``
+        and confidence scores with shape ``(shots,)``.
+        """
+
+        single_shot = detector_bits.ndim == 1
+        decoded_obs, logical_gaps = self._decode_with_logical_gap(
+            detector_bits, verbose=self._verbose
         )
-        if is_single_shot:
-            return result[0], float(confidence[0])
-        return result, confidence
+
+        decoded_obs = decoded_obs.astype(np.bool_)
+        logical_gaps = np.asarray(logical_gaps, dtype=np.float64).reshape(-1)
+        confidence = np.tanh(np.maximum(logical_gaps, 0.0) / 2.0)
+
+        if single_shot:
+            return decoded_obs, float(confidence[0])
+
+        return decoded_obs, confidence

--- a/src/bloqade/decoders/_decoders/mle/decoder.py
+++ b/src/bloqade/decoders/_decoders/mle/decoder.py
@@ -424,6 +424,10 @@ class GurobiDecoder(BaseDecoder):
         Confidence thresholds are therefore not interchangeable between the
         MLE and MLD decoders without calibration.
 
+        A simple alternative to calibrating the confidences across decoders would be to sort
+        the results of various decoders by confidence, and subsequently do thresholding
+        based on the accepted fraction of shots instead of by the raw confidence threshold value.
+
         A single detector shot returns one correction and a scalar confidence.
         A batch returns corrections with shape ``(shots, num_observables)``
         and confidence scores with shape ``(shots,)``.

--- a/src/bloqade/decoders/_decoders/mle/decoder.py
+++ b/src/bloqade/decoders/_decoders/mle/decoder.py
@@ -142,7 +142,9 @@ class GurobiDecoder(BaseDecoder):
     def weight_from_error(self, error: np.ndarray) -> np.ndarray:
         return np.sum(error * self._weights, axis=1)
 
-    def _decode_error(self, det_shots: np.ndarray) -> np.ndarray:
+    def _decode_error(
+        self, det_shots: np.ndarray, confidence: np.ndarray | None = None
+    ) -> np.ndarray:
         import gurobipy as gp
         from gurobipy import GRB
 
@@ -192,9 +194,9 @@ class GurobiDecoder(BaseDecoder):
                 if self._verbose:
                     print("Did not find optimal solution", m.status)
                 m.close()
-                raise RuntimeError(
-                    f"Gurobi did not find an optimal solution. Status: {m.status}"
-                )
+                if confidence is not None:
+                    confidence[d] = 0.0
+                continue
             error = np.round(
                 np.array([e.X for e in error_variables]), decimals=0
             ).astype(bool)
@@ -215,25 +217,35 @@ class GurobiDecoder(BaseDecoder):
                     ) % 2
         return logicals.astype(bool)
 
+    def _decode_batch(
+        self, detector_bits: npt.NDArray[np.bool_]
+    ) -> tuple[npt.NDArray[np.bool_], npt.NDArray[np.float64]]:
+        confidence = np.ones(len(detector_bits), dtype=np.float64)
+        errors = self._decode_error(detector_bits, confidence)
+        result = self.logical_from_error(errors)
+        result[confidence == 0.0] = False
+        return result, confidence
+
     def _decode(self, detector_bits: npt.NDArray[np.bool_]) -> npt.NDArray[np.bool_]:
         """Decode a single shot of detector bits."""
-        det_2d = detector_bits.reshape(1, -1)
-        errors = self._decode_error(det_2d)
-        obs = self.logical_from_error(errors)
-        return obs[0].astype(np.bool_)
+        result, _ = self._decode_batch(detector_bits.reshape(1, -1))
+        return result[0]
 
     def decode(self, detector_bits: npt.NDArray[np.bool_]) -> npt.NDArray[np.bool_]:
         """Decode a batch or single shot of detector bits."""
         if detector_bits.ndim == 1:
             return self._decode(detector_bits)
-        errors = self._decode_error(detector_bits)
-        return self.logical_from_error(errors)
+        result, _ = self._decode_batch(detector_bits)
+        return result
 
     def decode_confidence(
         self, detector_bits: npt.NDArray[np.bool_]
     ) -> tuple[npt.NDArray[np.bool_], float | npt.NDArray[np.float64]]:
         """Decode detector bits with the default confidence score."""
-        result = self.decode(detector_bits)
-        if detector_bits.ndim == 1:
-            return result, 1.0
-        return result, np.ones(len(detector_bits), dtype=np.float64)
+        is_single_shot = detector_bits.ndim == 1
+        result, confidence = self._decode_batch(
+            detector_bits.reshape(1, -1) if is_single_shot else detector_bits
+        )
+        if is_single_shot:
+            return result[0], float(confidence[0])
+        return result, confidence

--- a/src/bloqade/decoders/_decoders/mle/decoder.py
+++ b/src/bloqade/decoders/_decoders/mle/decoder.py
@@ -269,9 +269,9 @@ class GurobiDecoder(BaseDecoder):
         detector_vertices = self._detector_vertices
         observable_indices = self._observable_indices
 
-        error_variables: list["gp.Var"] = []
-        detector_variables: list["gp.Var"] = []
-        logical_variables: list["gp.Var"] = []
+        error_variables: list[gp.Var] = []
+        detector_variables: list[gp.Var] = []
+        logical_variables: list[gp.Var] = []
         objective: gp.LinExpr = gp.LinExpr(0)
 
         for i, weight in enumerate(weights):
@@ -318,7 +318,7 @@ class GurobiDecoder(BaseDecoder):
             m.addConstr(constraint == logical_var, name="lpar" + str(obs_idx))
 
         if forbidden_logical is not None:
-            diff_variables: list["gp.Var"] = []
+            diff_variables: list[gp.Var] = []
             for obs_idx, forbidden_bit in enumerate(forbidden_logical.astype(int)):
                 diff_var = m.addVar(vtype=GRB.BINARY, name="d" + str(obs_idx))
                 diff_variables.append(diff_var)

--- a/src/bloqade/decoders/_decoders/tesseract.py
+++ b/src/bloqade/decoders/_decoders/tesseract.py
@@ -57,7 +57,7 @@ class TesseractDecoder(BaseDecoder):
         no_revisit_dets: bool = False,
         verbose: bool = False,
         pqlimit: int = 200_000,
-        det_orders: list[list[int]] = [],
+        det_orders: list[list[int]] | None = None,
         det_penalty: float = 0.0,
         **_kwargs: Any,
     ):
@@ -68,6 +68,9 @@ class TesseractDecoder(BaseDecoder):
                 "The tesseract-decoder package is required for TesseractDecoder. "
                 'You can install it via: pip install "tesseract-decoder"'
             ) from e
+
+        if det_orders is None:
+            det_orders = []
 
         if det_beam is None:
             det_beam = tesseract.INF_DET_BEAM

--- a/src/bloqade/decoders/dialects/annotate/types.py
+++ b/src/bloqade/decoders/dialects/annotate/types.py
@@ -91,13 +91,9 @@ class MeasurementResult:
 class Detector:
     """Type marker returned when a detector parity is declared."""
 
-    pass
-
 
 class Observable:
     """Type marker returned when an observable parity is declared."""
-
-    pass
 
 
 # Kirin IR types

--- a/src/bloqade/decoders/dialects/immediate_loop/_interface.py
+++ b/src/bloqade/decoders/dialects/immediate_loop/_interface.py
@@ -1,4 +1,5 @@
-from typing import Any, TypeVar, Callable
+from typing import Any, TypeVar
+from collections.abc import Callable
 
 from kirin.dialects import ilist
 from kirin.lowering import wraps

--- a/test/decoders/test_mld.py
+++ b/test/decoders/test_mld.py
@@ -143,6 +143,16 @@ def test_decode_confidence():
     np.testing.assert_array_equal(confidence, np.array([1.0, 1.0]))
 
 
+def test_decode_confidence_is_empirical_fraction():
+    dem = stim.DetectorErrorModel("error(0.1) D0 L0\nerror(0.1) D1 L0\n")
+    decoder = _trained_decoder_from_counts(dem, np.array([0, 0, 1, 0, 0, 0, 9, 0]))
+
+    result, confidence = decoder.decode_confidence(np.array([0, 1], dtype=bool))
+
+    np.testing.assert_array_equal(result, np.array([True]))
+    assert confidence == pytest.approx(0.9)
+
+
 def test_single_shot_decode_confidence():
     dem = stim.DetectorErrorModel("error(0.1) D0 L0\nerror(0.1) D1 L0\n")
     decoder = _trained_decoder_from_counts(dem, np.array([81, 0, 0, 1, 0, 9, 9, 0]))

--- a/test/decoders/test_mld.py
+++ b/test/decoders/test_mld.py
@@ -153,6 +153,23 @@ def test_single_shot_decode_confidence():
     np.testing.assert_array_equal(result, np.array([True]))
 
 
+def test_unseen_syndrome_has_zero_confidence():
+    dem = stim.DetectorErrorModel("error(0.1) D0 L0\nerror(0.1) D1 L0\n")
+    decoder = _trained_decoder_from_counts(dem, np.array([1, 0, 0, 0, 0, 1, 0, 0]))
+
+    result, confidence = decoder.decode_confidence(
+        np.array([[0, 0], [1, 0], [0, 1]], dtype=bool)
+    )
+
+    np.testing.assert_array_equal(result, np.array([[False], [True], [False]]))
+    np.testing.assert_array_equal(confidence, np.array([1.0, 1.0, 0.0]))
+
+    result, confidence = decoder.decode_confidence(np.array([0, 1], dtype=bool))
+
+    np.testing.assert_array_equal(result, np.array([False]))
+    assert confidence == 0.0
+
+
 def test_table_decoder_can_instantiate_without_training():
     decoder = TableDecoder.instantiate(simple_dem())
 

--- a/test/decoders/test_mle.py
+++ b/test/decoders/test_mle.py
@@ -1,4 +1,5 @@
 import math
+from unittest.mock import Mock
 
 import stim
 import numpy as np
@@ -135,6 +136,30 @@ def test_single_shot_decode_confidence():
 
     assert confidence == 1.0
     np.testing.assert_array_equal(result, np.array([True]))
+
+
+def test_nonoptimal_status_has_zero_confidence(monkeypatch):
+    import gurobipy as gp
+    from gurobipy import GRB
+
+    decoder = GurobiDecoder(stim.DetectorErrorModel("error(0) L0"))
+    models = [Mock(status=GRB.INFEASIBLE), Mock(status=GRB.OPTIMAL)]
+    monkeypatch.setattr(gp, "Model", Mock(side_effect=models))
+    monkeypatch.setattr(gp, "Env", Mock(return_value=Mock()))
+    monkeypatch.setattr(GurobiDecoder, "_env", None)
+
+    result, confidence = decoder.decode_confidence(np.empty((2, 0), dtype=bool))
+
+    np.testing.assert_array_equal(result, np.array([[False], [False]]))
+    np.testing.assert_array_equal(confidence, np.array([0.0, 1.0]))
+
+    monkeypatch.setattr(gp, "Model", Mock(return_value=Mock(status=GRB.INFEASIBLE)))
+    np.testing.assert_array_equal(decoder.decode(np.empty(0, dtype=bool)), [False])
+
+    result, confidence = decoder.decode_confidence(np.empty(0, dtype=bool))
+
+    np.testing.assert_array_equal(result, np.array([False]))
+    assert confidence == 0.0
 
 
 # --- SinterGurobiDecoder tests ---

--- a/test/decoders/test_mle.py
+++ b/test/decoders/test_mle.py
@@ -1,5 +1,4 @@
 import math
-from unittest.mock import Mock
 
 import stim
 import numpy as np
@@ -124,7 +123,8 @@ def test_decode_confidence():
     result, confidence = decoder.decode_confidence(det_shots)
 
     np.testing.assert_array_equal(result, obs_shots)
-    np.testing.assert_array_equal(confidence, np.array([1.0, 1.0]))
+    expected = np.tanh(4 * np.log(9))
+    np.testing.assert_allclose(confidence, np.full(2, expected))
 
 
 def test_single_shot_decode_confidence():
@@ -134,32 +134,77 @@ def test_single_shot_decode_confidence():
 
     result, confidence = decoder.decode_confidence(det_shots)
 
-    assert confidence == 1.0
+    assert np.isclose(confidence, np.tanh(4 * np.log(9)))
     np.testing.assert_array_equal(result, np.array([True]))
 
 
-def test_nonoptimal_status_has_zero_confidence(monkeypatch):
-    import gurobipy as gp
-    from gurobipy import GRB
+def test_equal_likelihood_alternatives_have_zero_confidence():
+    dem = stim.DetectorErrorModel("""
+        error(0.1) D0 L0
+        error(0.1) D0
+        """)
+    decoder = GurobiDecoder(dem)
 
-    decoder = GurobiDecoder(stim.DetectorErrorModel("error(0) L0"))
-    models = [Mock(status=GRB.INFEASIBLE), Mock(status=GRB.OPTIMAL)]
-    monkeypatch.setattr(gp, "Model", Mock(side_effect=models))
-    monkeypatch.setattr(gp, "Env", Mock(return_value=Mock()))
-    monkeypatch.setattr(GurobiDecoder, "_env", None)
+    result, confidence = decoder.decode_confidence(np.array([True], dtype=bool))
 
-    result, confidence = decoder.decode_confidence(np.empty((2, 0), dtype=bool))
+    assert result.shape == (1,)
+    assert confidence == pytest.approx(0.0)
+
+
+def test_finite_logical_gap_has_normalized_confidence():
+    dem = stim.DetectorErrorModel("""
+        error(0.75) D0 L0
+        error(0.25) D0
+        """)
+    decoder = GurobiDecoder(dem)
+
+    result, confidence = decoder.decode_confidence(np.array([True], dtype=bool))
+
+    np.testing.assert_array_equal(result, np.array([True]))
+    assert confidence == pytest.approx(0.8)
+
+
+def test_nonoptimal_status_has_zero_confidence():
+    dem = stim.DetectorErrorModel("""
+        detector D0
+        error(0) L0
+        """)
+    decoder = GurobiDecoder(dem)
+
+    result, confidence = decoder.decode_confidence(
+        np.array([[True], [False]], dtype=bool)
+    )
 
     np.testing.assert_array_equal(result, np.array([[False], [False]]))
-    np.testing.assert_array_equal(confidence, np.array([0.0, 1.0]))
+    assert isinstance(confidence, np.ndarray)
+    assert confidence[0] == 0.0
+    assert confidence[1] == 1.0
 
-    monkeypatch.setattr(gp, "Model", Mock(return_value=Mock(status=GRB.INFEASIBLE)))
-    np.testing.assert_array_equal(decoder.decode(np.empty(0, dtype=bool)), [False])
-
-    result, confidence = decoder.decode_confidence(np.empty(0, dtype=bool))
+    result, confidence = decoder.decode_confidence(np.array([True], dtype=bool))
 
     np.testing.assert_array_equal(result, np.array([False]))
     assert confidence == 0.0
+
+
+def test_nonoptimal_alternative_solve_has_zero_confidence(monkeypatch):
+    decoder = GurobiDecoder(stim.DetectorErrorModel("error(0.1) D0 L0"))
+    best = decoder._ConfidenceSolveResult(
+        error=np.array([True]),
+        logical=np.array([True]),
+        objective=1.0,
+    )
+
+    def solve(detector_shot, *, verbose=False, forbidden_logical=None):
+        if forbidden_logical is None:
+            return best, True
+        return None, False
+
+    monkeypatch.setattr(decoder, "_solve_single_shot_for_confidence", solve)
+
+    result, confidence = decoder.decode_confidence(np.array([[True]], dtype=bool))
+
+    np.testing.assert_array_equal(result, np.array([[False]]))
+    np.testing.assert_array_equal(confidence, np.array([0.0]))
 
 
 # --- SinterGurobiDecoder tests ---
@@ -359,3 +404,19 @@ def test_prob_one_error_pre_applied():
     assert result.shape == (1, 1)
     # The certain error flips L0, so the observable should be True
     assert result[0, 0]
+
+
+def test_decode_confidence_includes_prob_one_error_contributions():
+    dem = stim.DetectorErrorModel("""
+        error(1.0) D0 L0
+        error(0.1) D1 L0
+        """)
+    decoder = GurobiDecoder(dem)
+
+    result, confidence = decoder.decode_confidence(
+        np.array([[1, 0], [1, 1]], dtype=bool)
+    )
+
+    np.testing.assert_array_equal(result, np.array([[True], [False]]))
+    assert isinstance(confidence, np.ndarray)
+    np.testing.assert_array_equal(confidence, np.ones(2))

--- a/test/test_measurement_xor_typeinfer.py
+++ b/test/test_measurement_xor_typeinfer.py
@@ -1,4 +1,4 @@
-from kirin import passes, types
+from kirin import types, passes
 from kirin.prelude import structural_no_opt
 
 from bloqade.decoders.dialects.annotate.types import (


### PR DESCRIPTION
Depends on https://github.com/QuEraComputing/bloqade-decoders/pull/53 for ruff updates.

- Added confidence for batched MLD decoder by taking the marginal probability of the correction over the counts of all the other corrections.
- Added confidence for batched MLE decoder by taking the ratio of the log likelihood of the most likely and second most likely observable correction. (mirrors MSD paper: https://arxiv.org/abs/2412.15165)
- Normalized confidence for MLE decoder so that confidence is between 0 and 1 via `tanh(x / 2)`
- Various fixes to linter