### PR TITLE
Bump precommit ruff version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,9 +17,9 @@ repos:
   rev: 26.3.1
   hooks:
     - id: black
-- repo: https://github.com/charliermarsh/ruff-pre-commit
+- repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: "v0.15.7"
+  rev: "v0.16.0"
   hooks:
     - id: ruff
       name: ruff (lint)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,19 @@ exclude = [
 
 [tool.ruff.lint]
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+ignore = [
+    # Import ordering is owned by the dedicated isort pre-commit hook (profile
+    # black); leaving it to ruff too would make the two tools fight.
+    "I001",
+    # `from x import y as y` is the explicit re-export idiom pyright requires;
+    # ruff would otherwise strip the alias and break re-export detection.
+    "PLC0414",
+    # PLR0402's autofix rewrites `import pkg.sub as sub` to `from pkg import
+    # sub`, which is NOT equivalent here: the former guarantees the submodule,
+    # the latter resolves via pkg/__init__ and makes pyright lose the
+    # submodule's types (breaks squin/gemini attribute typing).
+    "PLR0402",
+]
 
 [tool.coverage.run]
 include = ["src/bloqade/*"]

--- a/src/bloqade/decoders/_decoders/base.py
+++ b/src/bloqade/decoders/_decoders/base.py
@@ -4,6 +4,7 @@ from typing import Any, TypeVar
 import stim
 import numpy as np
 import numpy.typing as npt
+from typing_extensions import Self
 
 DecoderT = TypeVar("DecoderT", bound="BaseDecoder")
 
@@ -15,9 +16,7 @@ class BaseDecoder(ABC):
         self.train(**kwargs)
 
     @classmethod
-    def instantiate(
-        cls: type[DecoderT], dem: stim.DetectorErrorModel, **kwargs: Any
-    ) -> DecoderT:
+    def instantiate(cls, dem: stim.DetectorErrorModel, **kwargs: Any) -> Self:
         """Configure an untrained decoder from constructor keyword arguments."""
         decoder = cls.__new__(cls)
         decoder.dem = dem
@@ -26,7 +25,6 @@ class BaseDecoder(ABC):
 
     def _instantiate(self, **kwargs: Any) -> None:
         """Configure the decoder from constructor keyword arguments."""
-        pass
 
     @property
     def num_detectors(self) -> int:
@@ -41,12 +39,10 @@ class BaseDecoder(ABC):
 
         The default is a no-op for decoders that do not need training.
         """
-        pass
 
     @abstractmethod
     def _decode(self, detector_bits: npt.NDArray[np.bool_]) -> npt.NDArray[np.bool_]:
         """Decode a single shot of detector bits."""
-        pass
 
     def decode(self, detector_bits: npt.NDArray[np.bool_]) -> npt.NDArray[np.bool_]:
         """Decode a batch or single shot of detector bits.

--- a/src/bloqade/decoders/_decoders/mle/decoder.py
+++ b/src/bloqade/decoders/_decoders/mle/decoder.py
@@ -39,7 +39,7 @@ class GurobiDecoder(BaseDecoder):
             ) from e
 
         try:
-            import scipy.sparse  # noqa: F401
+            import scipy.sparse
         except ImportError as e:
             raise ImportError(
                 "The scipy package is required for GurobiDecoder. "
@@ -64,7 +64,7 @@ class GurobiDecoder(BaseDecoder):
 
         for instruction in self._flat_dem:  # type: ignore[union-attr]
             if not isinstance(instruction, DemInstruction):
-                raise Exception(
+                raise TypeError(
                     "The detector-error model should be already flattened. But still got DemRepeatBlock."
                 )
             if instruction.type != "error":
@@ -81,8 +81,7 @@ class GurobiDecoder(BaseDecoder):
                     det_targets.append(target.val)
                 else:
                     obs_targets.append(target.val)
-                    if target.val > max_observable_index:
-                        max_observable_index = target.val
+                    max_observable_index = max(max_observable_index, target.val)
 
             if probability == 1:
                 # Certain errors always fire: pre-apply their contributions

--- a/src/bloqade/decoders/_decoders/tesseract.py
+++ b/src/bloqade/decoders/_decoders/tesseract.py
@@ -57,7 +57,7 @@ class TesseractDecoder(BaseDecoder):
         no_revisit_dets: bool = False,
         verbose: bool = False,
         pqlimit: int = 200_000,
-        det_orders: list[list[int]] = [],
+        det_orders: list[list[int]] | None = None,
         det_penalty: float = 0.0,
         **_kwargs: Any,
     ):
@@ -68,6 +68,9 @@ class TesseractDecoder(BaseDecoder):
                 "The tesseract-decoder package is required for TesseractDecoder. "
                 'You can install it via: pip install "tesseract-decoder"'
             ) from e
+
+        if det_orders is None:
+            det_orders = []
 
         if det_beam is None:
             det_beam = tesseract.INF_DET_BEAM

--- a/src/bloqade/decoders/dialects/annotate/types.py
+++ b/src/bloqade/decoders/dialects/annotate/types.py
@@ -91,13 +91,9 @@ class MeasurementResult:
 class Detector:
     """Type marker returned when a detector parity is declared."""
 
-    pass
-
 
 class Observable:
     """Type marker returned when an observable parity is declared."""
-
-    pass
 
 
 # Kirin IR types

--- a/src/bloqade/decoders/dialects/immediate_loop/_interface.py
+++ b/src/bloqade/decoders/dialects/immediate_loop/_interface.py
@@ -1,4 +1,5 @@
-from typing import Any, TypeVar, Callable
+from typing import Any, TypeVar
+from collections.abc import Callable
 
 from kirin.dialects import ilist
 from kirin.lowering import wraps

--- a/test/test_measurement_xor_typeinfer.py
+++ b/test/test_measurement_xor_typeinfer.py
@@ -1,4 +1,4 @@
-from kirin import passes, types
+from kirin import types, passes
 from kirin.prelude import structural_no_opt
 
 from bloqade.decoders.dialects.annotate.types import (


### PR DESCRIPTION
Ruff updated its version (CI uses latest version of ruff; thus the ruff version used by CI changed), so we want to update the version of ruff locally for pre-commit to pass.
- Added some ignores in "pyproject.toml" for ruff, mirroring bloqade-lanes: https://github.com/QuEraComputing/bloqade-lanes/blob/main/pyproject.toml
- Miscellaneous changes to get ruff to pass CI